### PR TITLE
Fix DQN compile loss for Keras 3

### DIFF
--- a/src/agents/agent_dqn.py
+++ b/src/agents/agent_dqn.py
@@ -45,7 +45,7 @@ class AgentDQN(BaseAgent):
         x = Dense(64, activation="relu")(x)
         out = Dense(200, activation="linear")(x)
         self.model = Model(inp, out)
-        self.model.compile(optimizer=Adam(self.lr), loss="mse")
+        self.model.compile(optimizer=Adam(self.lr), loss="mean_squared_error")
 
     # ------------------------------------------------------------------
     # Game update callbacks


### PR DESCRIPTION
## Summary
- fix AgentDQN model compile for new Keras version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68546f069d5083229d8784a2a4286be4