### PR TITLE
Fix log disabling for EngineLogger

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -39,6 +39,11 @@ def get_logger(logger_name, log_directory, log_name, verbose_console, verbose_lo
 
         logger.addHandler(console_handler)
 
+    if not verbose_console and not verbose_log:
+        logger.addHandler(logging.NullHandler())
+
+    logger.propagate = False
+
     return logger
 
 
@@ -81,6 +86,9 @@ class BaseAgent:
             verbose_console,
             verbose_log,
         )
+
+        if not verbose_console and not verbose_log:
+            self.log = lambda message: None
 
         self.log("---------------------------")
         self.log(f"Player {self.name} created!")

--- a/src/core/logging/engine_logger.py
+++ b/src/core/logging/engine_logger.py
@@ -36,8 +36,8 @@ class EngineLogger:
         self._log_game_start()
 
     def _noop_all(self):
-        self.log_room_intro = lambda: None
-        self.room_log = lambda message: None
+        """Disable all logging methods when logs are not saved."""
+        self.engine_log = lambda message: None
 
     def _init_logger(self, name, filepath):
         logger = logging.getLogger(name)


### PR DESCRIPTION
## Summary
- ensure EngineLogger disables logging methods correctly when logs are off
- silence BaseAgent logger completely when both console and file logging are disabled

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68547999caf0832293a24317e1d36d13