### PR TITLE
Fix JSON serialization and add websocket dependency

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -4,3 +4,4 @@ numpy==1.26.1
 pandas==2.1.1
 python_dateutil==2.8.2
 opencv-python==4.8.1.78
+websockets==15.0.1

--- a/src/rooms/room.py
+++ b/src/rooms/room.py
@@ -267,7 +267,7 @@ class Room:
             "update_game_start",
             self.connected_players.values(),
             {
-                "opponents": self.connected_players.keys(),
+                "opponents": list(self.connected_players.keys()),
                 "actions": self.action_lookup,
                 "max_rounds": self.game.max_rounds,
                 "max_matches": self.game.max_matches,


### PR DESCRIPTION
## Summary
- fix JSON serialization bug in game start update
- specify websockets dependency in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68547dcc3bd88322b7f009c148967f02