### PR TITLE
Handle remote websocket closures gracefully

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -176,18 +176,21 @@ class BaseAgent:
     async def remote_loop(self):
         if not self.ws:
             await self.connect_remote()
-        while True:
-            msg = await self.ws.recv()
-            data = json.loads(msg)
-            mtype = data.get("type")
-            payload = data.get("payload", {})
-            if mtype.startswith("request_"):
-                method = getattr(self, mtype)
-                result = method(payload)
-                await self.ws.send(json.dumps({"result": result}))
-            else:
-                method = getattr(self, mtype, None)
-                if method:
-                    method(payload)
+        try:
+            while True:
+                msg = await self.ws.recv()
+                data = json.loads(msg)
+                mtype = data.get("type")
+                payload = data.get("payload", {})
+                if mtype.startswith("request_"):
+                    method = getattr(self, mtype)
+                    result = method(payload)
+                    await self.ws.send(json.dumps({"result": result}))
+                else:
+                    method = getattr(self, mtype, None)
+                    if method:
+                        method(payload)
+        except websockets.exceptions.ConnectionClosed:
+            pass
 
 

--- a/src/rooms/remote_communication.py
+++ b/src/rooms/remote_communication.py
@@ -19,7 +19,10 @@ class RemoteComm(AgentCommInterface):
         payload = args[0] if args else {}
         name = self.room.websockets.get(agent, "unknown")
         self.logger.room_log(f"Notify ONE -> {name} | method={method} | args={args}")
-        await agent.send(json.dumps({"type": method, "payload": payload}))
+        try:
+            await agent.send(json.dumps({"type": method, "payload": payload}))
+        except websockets.exceptions.ConnectionClosed:
+            await self.room.handle_disconnect(name)
 
     async def request_one(self, agent, method, *args):
         payload = args[0] if args else {}


### PR DESCRIPTION
## Summary
- avoid crashes when a websocket connection closes in `RemoteComm.notify_one`
- catch `websockets.exceptions.ConnectionClosed` in `BaseAgent.remote_loop`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68547ff4da0c83229c4f7445530cfd22