### PR TITLE
Fix remote WebSocket handling

### DIFF
--- a/src/rooms/room.py
+++ b/src/rooms/room.py
@@ -147,8 +147,13 @@ class Room:
                     if len(self.connected_players) == self.max_players:
                         self._waiting_event.set()
 
-                    # Keep connection alive until game starts, then handle in game loop
+                    # Keep connection alive until the game finishes.  The
+                    # websocket library closes the connection once this handler
+                    # returns, so wait here until the room signals that the game
+                    # has started and later until the connection is closed by
+                    # the agent or the server.
                     await self._waiting_event.wait()
+                    await websocket.wait_closed()
                 except Exception as e:
                     print("WebSocket handler error:", e)
                     await websocket.close()


### PR DESCRIPTION
## Summary
- keep incoming WebSocket connections alive during remote play

## Testing
- `python -m py_compile src/test_room_remote.py src/rooms/room.py src/rooms/remote_communication.py src/agents/random_agent.py src/agents/base_agent.py`
- `python src/test_room_remote.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854853c42648322be41a48a3bf7178c