### PR TITLE
Fix remote notification race conditions

### DIFF
--- a/src/rooms/room.py
+++ b/src/rooms/room.py
@@ -142,6 +142,8 @@ class Room:
                     self.websockets[websocket] = player_name
                     self.name_to_websocket[player_name] = websocket
                     self.invalid_counts[player_name] = 0
+                    if hasattr(self.comm, "register_websocket"):
+                        self.comm.register_websocket(websocket)
                     await websocket.send(json.dumps({"status": "connected"}))
 
                     if len(self.connected_players) == self.max_players:
@@ -187,6 +189,8 @@ class Room:
             except Exception:
                 pass
             self.websockets.pop(ws, None)
+            if hasattr(self.comm, "unregister_websocket"):
+                self.comm.unregister_websocket(ws)
             self.name_to_websocket.pop(player_name, None)
         from agents.random_agent import RandomAgent
 


### PR DESCRIPTION
## Summary
- serialize websocket sends in `RemoteComm` using per-socket locks
- register/unregister websockets with `RemoteComm` from `Room`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685487249ef0832289365d6dfabac4a4