### PR TITLE
Fix remote update_player_action name lookup

### DIFF
--- a/src/rooms/room.py
+++ b/src/rooms/room.py
@@ -463,7 +463,12 @@ class Room:
                     }
 
                     for agent in self.connected_players.values():
-                        if agent.name == player_name:
+                        name = (
+                            agent.name
+                            if not self.run_remote_room
+                            else self.websockets.get(agent, "unknown")
+                        )
+                        if name == player_name:
                             action_info["observation_before"] = result_before_action[
                                 "observation"
                             ]


### PR DESCRIPTION
## Summary
- ensure room handles websocket players when broadcasting `update_player_action`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68548bf0290c8322860a37f22b6f9cf5