### PR TITLE
Handle remote cleanup on game over

### DIFF
--- a/src/agents/base_agent.py
+++ b/src/agents/base_agent.py
@@ -203,9 +203,13 @@ class BaseAgent:
                     method = getattr(self, mtype, None)
                     if method:
                         method(payload)
+                if mtype == "update_game_over":
+                    break
         except asyncio.CancelledError:
             if self.ws:
                 await self.ws.close()
             raise
+        if self.ws:
+            await self.ws.close()
 
 

--- a/src/rooms/room.py
+++ b/src/rooms/room.py
@@ -516,3 +516,15 @@ class Room:
         self.room_logger.room_log(f"Final scores: {self.game.scores}")
 
         self.final_scores = self.game.scores
+
+        if self.run_remote_room:
+            for ws in list(self.websockets.keys()):
+                try:
+                    await ws.close()
+                except Exception:
+                    pass
+                if hasattr(self.comm, "unregister_websocket"):
+                    self.comm.unregister_websocket(ws)
+                self.websockets.pop(ws, None)
+            self.name_to_websocket.clear()
+            await self.close()

--- a/src/test_room_remote.py
+++ b/src/test_room_remote.py
@@ -33,8 +33,6 @@ async def run_room_server(tmp_path):
 
     agent_tasks = [asyncio.create_task(a.remote_loop()) for a in agents]
     await room.run()
-    for t in agent_tasks:
-        t.cancel()
     await asyncio.gather(*agent_tasks, return_exceptions=True)
     assert hasattr(room, "final_scores")
 

--- a/test/test_room_remote.py
+++ b/test/test_room_remote.py
@@ -26,8 +26,6 @@ async def run_room_server(tmp_path):
         a.remote_room_password = room.room_password
     agent_tasks = [asyncio.create_task(a.remote_loop()) for a in agents]
     await room.run()
-    for t in agent_tasks:
-        t.cancel()
     await asyncio.gather(*agent_tasks, return_exceptions=True)
     assert hasattr(room, "final_scores")
 


### PR DESCRIPTION
## Summary
- stop the agent's remote loop when the game ends
- close agent connections when the room finishes
- let remote-room tests rely on automatic agent shutdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685490585d008322988460b9a20d0896