### PR TITLE
Fix Round dtype before HDF export

### DIFF
--- a/src/core/dataset/dataset_manager.py
+++ b/src/core/dataset/dataset_manager.py
@@ -114,6 +114,12 @@ class DataSetManager:
 
             # Efficiently append to HDF5 instead of rewriting a pickle file
             combined_df.reset_index(drop=True, inplace=True)
+
+            # Ensure numeric columns use a consistent dtype when saving to HDF5
+            if "Match" in combined_df.columns:
+                combined_df["Match"] = combined_df["Match"].astype("int64")
+            if "Round" in combined_df.columns:
+                combined_df["Round"] = combined_df["Round"].astype("int64")
             combined_df.to_hdf(
                 self.currentDataSetFile,
                 key="data",


### PR DESCRIPTION
## Summary
- cast `Match` and `Round` columns to integers in `DataSetManager.flush_to_disk`
- avoid PyTables type error when dataset is saved

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e729081cc832295250595b941c2c0