### PR TITLE
Fix dtype casting for dataset flush

### DIFF
--- a/src/core/dataset/dataset_manager.py
+++ b/src/core/dataset/dataset_manager.py
@@ -117,9 +117,9 @@ class DataSetManager:
 
             # Ensure numeric columns use a consistent dtype when saving to HDF5
             if "Match" in combined_df.columns:
-                combined_df["Match"] = combined_df["Match"].astype("int64")
+                combined_df["Match"] = combined_df["Match"].astype("Int64")
             if "Round" in combined_df.columns:
-                combined_df["Round"] = combined_df["Round"].astype("int64")
+                combined_df["Round"] = combined_df["Round"].astype("Int64")
             combined_df.to_hdf(
                 self.currentDataSetFile,
                 key="data",


### PR DESCRIPTION
## Summary
- allow nulls when casting `Match` and `Round` columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686e744c3e70832294bdb98e722c8d3c