### PR TITLE
Handle string/None values when casting dataset columns

### DIFF
--- a/src/core/dataset/dataset_manager.py
+++ b/src/core/dataset/dataset_manager.py
@@ -116,10 +116,20 @@ class DataSetManager:
             combined_df.reset_index(drop=True, inplace=True)
 
             # Ensure numeric columns use a consistent dtype when saving to HDF5
+            # Values might come through as strings or ``None`` which would
+            # normally cause ``astype`` to fail. ``to_numeric`` coerces
+            # non-numeric values to ``NaN`` so they can be stored using the
+            # nullable ``Int64`` dtype.
             if "Match" in combined_df.columns:
-                combined_df["Match"] = combined_df["Match"].astype("Int64")
+                combined_df["Match"] = (
+                    pd.to_numeric(combined_df["Match"], errors="coerce")
+                    .astype("Int64")
+                )
             if "Round" in combined_df.columns:
-                combined_df["Round"] = combined_df["Round"].astype("Int64")
+                combined_df["Round"] = (
+                    pd.to_numeric(combined_df["Round"], errors="coerce")
+                    .astype("Int64")
+                )
             combined_df.to_hdf(
                 self.currentDataSetFile,
                 key="data",


### PR DESCRIPTION
## Summary
- prevent errors when saving the dataset by coercing non-numeric values before setting integer dtypes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686e7689b7f48322a40b06d16ff5bc08