### PR TITLE
Fix log/dataset collision when creating multiple rooms

### DIFF
--- a/src/rooms/room.py
+++ b/src/rooms/room.py
@@ -57,7 +57,9 @@ class Room:
 
         self._waiting_event = asyncio.Event()
 
-        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Use microseconds in the timestamp to avoid collisions when multiple
+        # rooms are created within the same second.
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self.room_dir = os.path.join(output_folder, f"{room_name}_{self.timestamp }")
         os.makedirs(self.room_dir, exist_ok=True)
 

--- a/src/rooms/room_old.py
+++ b/src/rooms/room_old.py
@@ -28,7 +28,8 @@ class Room:
         self.max_invalid_attempts = max_invalid_attemps_per_player
         self.invalid_counts = {agent.name: 0 for agent in player_agents}
 
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        # Include microseconds so directories are always unique
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         self.room_dir = os.path.join(output_folder, f"{room_name}_{timestamp}")
         os.makedirs(self.room_dir, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- use microseconds in room timestamp so each room gets a unique directory

## Testing
- `pytest -q` *(fails: pandas and numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876c33da4388322b20ebd9a6608c567